### PR TITLE
URL Cleanup

### DIFF
--- a/checks.gradle
+++ b/checks.gradle
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/dist.gradle
+++ b/dist.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,7 @@
 
 buildscript {
     repositories {
-        mavenRepo urls: 'http://repository.springsource.com/maven/bundles/release'
+        mavenRepo urls: 'https://repository.springsource.com/maven/bundles/release'
     }
     dependencies {
         classpath group: 'org.springframework.build',

--- a/docbook.gradle
+++ b/docbook.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 buildscript {
     repositories {
         mavenCentral()
-        mavenRepo name: 'Shibboleth Repo', urls: 'http://shibboleth.internet2.edu/downloads/maven2'
+        mavenRepo name: 'Shibboleth Repo', urls: 'https://www.internet2.edu/products-services/trust-identity-middleware/shibboleth'
     }
     dependencies {
         def fopDeps = ['org.apache.xmlgraphics:fop:0.95-1@jar',
@@ -265,7 +265,7 @@ class DocbookHtml extends Docbook {
 class DocbookFoPdf extends Docbook {
 
     /**
-     * <a href="http://xmlgraphics.apache.org/fop/0.95/embedding.html#render">From the FOP usage guide</a>
+     * <a href="https://xmlgraphics.apache.org/fop/0.95/embedding.html#render">From the FOP usage guide</a>
      */
     @Override
     protected void postTransform(File foFile) {

--- a/docs.gradle
+++ b/docs.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ task build(dependsOn: assemble) {
  *
  * @author Chris Beams
  * @author Luke Taylor
- * @see http://gradle.org/0.9-rc-1/docs/javadoc/org/gradle/api/tasks/javadoc/Javadoc.html
+ * @see https://gradle.org/0.9-rc-1/docs/javadoc/org/gradle/api/tasks/javadoc/Javadoc.html
  */
  task api(type: Javadoc) {
     group = 'Documentation'
@@ -46,7 +46,7 @@ task build(dependsOn: assemble) {
     tmpDir = file("${buildDir}/api-work")
     optionsFile = file("${tmpDir}/apidocs/javadoc.options")
     options.stylesheetFile = file("${srcDir}/spring-javadoc.css")
-    options.links = ["http://static.springframework.org/spring/docs/3.0.x/javadoc-api"]
+    options.links = ["https://docs.spring.io/spring/docs/3.0.x/javadoc-api"]
     options.overview = "${srcDir}/overview.html"
     options.docFilesSubDirs = true
     title = "${rootProject.description} ${version} API"
@@ -85,7 +85,7 @@ task build(dependsOn: assemble) {
  * a feature not yet implemented, but on the Gradle roadmap.
  *
  * @author Chris Beams
- * @see http://jira.codehaus.org/browse/GRADLE-1026
+ * @see https://jira.codehaus.org/browse/GRADLE-1026
  */
 task preprocessDocbookSources {
     description = 'Expands ${...} variables within docbook sources.'
@@ -149,8 +149,8 @@ docbookPdf.admonGraphicsPath = "${imagesDir}/admon/"
 
 /**
  *
- * @see http://www.gradle.org/0.9-preview-3/docs/userguide/userguide_single.html#sec:copying_files
- * @see http://www.gradle.org/0.9-preview-3/docs/javadoc/org/gradle/api/file/CopySpec.html
+ * @see https://www.gradle.org/0.9-preview-3/docs/userguide/userguide_single.html#sec:copying_files
+ * @see https://www.gradle.org/0.9-preview-3/docs/javadoc/org/gradle/api/file/CopySpec.html
  */
 docsSpec = copySpec {
     into("${version}") {

--- a/maven-deployment.gradle
+++ b/maven-deployment.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -71,7 +71,7 @@ artifacts {
  * @see 's3AccessKey' in gradle.properties
  * @see 's3SecretAccessKey' in gradle.properties
  * @see `gradle install` for deploying artifacts to the local .m2 cache
- * @see http://maven.apache.org/guides/mini/guide-central-repository-upload.html
+ * @see https://maven.apache.org/guides/mini/guide-central-repository-upload.html
  */
 uploadArchives {
     group = 'Buildmaster'
@@ -132,7 +132,7 @@ install {
  * within.
  *
  * @author Chris Beams
- * @see http://gradle.org/0.9-preview-3/docs/userguide/userguide_single.html#pomBuilder
+ * @see https://gradle.org/0.9-preview-3/docs/userguide/userguide_single.html#pomBuilder
  */
 task generatePom {
     group = 'Build'
@@ -272,7 +272,7 @@ def configurePom(def pom) {
         licenses {
             license {
                 name 'The Apache Software License, Version 2.0'
-                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                 distribution 'repo'
             }
         }

--- a/maven-root-pom.gradle
+++ b/maven-root-pom.gradle
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/wrapper.gradle
+++ b/wrapper.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,12 +20,12 @@
  * download and install gradle.
  *
  * @author Chris Beams
- * @see http://gradle.org/current/docs/userguide/gradle_wrapper.html
+ * @see https://gradle.org/current/docs/userguide/gradle_wrapper.html
  */
 task wrapper(type: Wrapper) {
     group = 'Buildmaster'
     description = "Generates gradlew and gradlew.bat bootstrap scripts"
     gradleVersion = '1.0-milestone-3'
-    distributionUrl='http://gradle.artifactoryonline.com/gradle/distributions/gradle-1.0-milestone-3-bin.zip'
+    distributionUrl='https://gradle.artifactoryonline.com/gradle/distributions/gradle-1.0-milestone-3-bin.zip'
     jarFile = 'buildSrc/wrapper/gradle-wrapper.jar'
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://jira.codehaus.org/browse/GRADLE-1026 (UnknownHostException) migrated to:  
  https://jira.codehaus.org/browse/GRADLE-1026 ([https](https://jira.codehaus.org/browse/GRADLE-1026) result UnknownHostException).
* http://gradle.artifactoryonline.com/gradle/distributions/gradle-1.0-milestone-3-bin.zip (404) migrated to:  
  https://gradle.artifactoryonline.com/gradle/distributions/gradle-1.0-milestone-3-bin.zip ([https](https://gradle.artifactoryonline.com/gradle/distributions/gradle-1.0-milestone-3-bin.zip) result 404).
* http://gradle.org/0.9-preview-3/docs/userguide/userguide_single.html (301) migrated to:  
  https://gradle.org/0.9-preview-3/docs/userguide/userguide_single.html ([https](https://gradle.org/0.9-preview-3/docs/userguide/userguide_single.html) result 404).
* http://gradle.org/0.9-rc-1/docs/javadoc/org/gradle/api/tasks/javadoc/Javadoc.html (301) migrated to:  
  https://gradle.org/0.9-rc-1/docs/javadoc/org/gradle/api/tasks/javadoc/Javadoc.html ([https](https://gradle.org/0.9-rc-1/docs/javadoc/org/gradle/api/tasks/javadoc/Javadoc.html) result 404).
* http://gradle.org/current/docs/userguide/gradle_wrapper.html (301) migrated to:  
  https://gradle.org/current/docs/userguide/gradle_wrapper.html ([https](https://gradle.org/current/docs/userguide/gradle_wrapper.html) result 404).
* http://repository.springsource.com/maven/bundles/release (404) migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://xmlgraphics.apache.org/fop/0.95/embedding.html migrated to:  
  https://xmlgraphics.apache.org/fop/0.95/embedding.html ([https](https://xmlgraphics.apache.org/fop/0.95/embedding.html) result 200).
* http://static.springframework.org/spring/docs/3.0.x/javadoc-api (301) migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api ([https](https://static.springframework.org/spring/docs/3.0.x/javadoc-api) result 301).
* http://maven.apache.org/guides/mini/guide-central-repository-upload.html migrated to:  
  https://maven.apache.org/guides/mini/guide-central-repository-upload.html ([https](https://maven.apache.org/guides/mini/guide-central-repository-upload.html) result 301).
* http://www.gradle.org/0.9-preview-3/docs/javadoc/org/gradle/api/file/CopySpec.html migrated to:  
  https://www.gradle.org/0.9-preview-3/docs/javadoc/org/gradle/api/file/CopySpec.html ([https](https://www.gradle.org/0.9-preview-3/docs/javadoc/org/gradle/api/file/CopySpec.html) result 301).
* http://www.gradle.org/0.9-preview-3/docs/userguide/userguide_single.html migrated to:  
  https://www.gradle.org/0.9-preview-3/docs/userguide/userguide_single.html ([https](https://www.gradle.org/0.9-preview-3/docs/userguide/userguide_single.html) result 301).
* http://shibboleth.internet2.edu/downloads/maven2 (301) migrated to:  
  https://www.internet2.edu/products-services/trust-identity-middleware/shibboleth ([https](https://shibboleth.internet2.edu/downloads/maven2) result 301).

# Ignored
These URLs were intentionally ignored.

* http://www.springframework.org/schema/