### PR TITLE
URL Cleanup

### DIFF
--- a/docbook.gradle
+++ b/docbook.gradle
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
 
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
         mavenRepo name: 'Shibboleth Repo', urls: 'http://shibboleth.internet2.edu/downloads/maven2'
     }
     dependencies {

--- a/wrapper/gradle-wrapper.properties
+++ b/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://gradle.artifactoryonline.com/gradle/distributions/gradle-1.0-milestone-3-bin.zip
+distributionUrl=https\://gradle.artifactoryonline.com/gradle/distributions/gradle-1.0-milestone-3-bin.zip


### PR DESCRIPTION
- Ensure Gradle Wrapper is downloaded via https
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.